### PR TITLE
add compatibility with ESP32-Arduino,

### DIFF
--- a/VEML7700.cpp
+++ b/VEML7700.cpp
@@ -63,7 +63,11 @@ receiveData(uint8_t command, uint16_t& data)
   if (Wire.write(command) != 1){
     return STATUS_ERROR;
   }
+#ifdef ARDUINO_ARCH_ESP32
+  if (Wire.endTransmission(false) !=7 ){  // NB: don't send stop here
+#else
   if (Wire.endTransmission(false)){  // NB: don't send stop here
+#endif
     return STATUS_ERROR;
   }
   if (Wire.requestFrom(uint8_t(I2C_ADDRESS), uint8_t(2)) != 2){


### PR DESCRIPTION
The ESP32 does not support naked ReSTART operations( START -> ReSTART), an I2C transaction must start with a START, and End with a STOP.  A ReSTART operation must be part of a START STOP sequence.  START -> ReSTART -> STOP.  So, this means that a naked ReSTART operation must be queued until a STOP is encountered.  This change cause Wire.endTransmission(false) to return an error code of 7 (continute).  Standard Arduino error checking code if(Wire.endTransmission(false)){} will always fail on ESP32-Arduino.  It must be changed to: if(Wire.endTransmission(false) !=7){} to operate properly.